### PR TITLE
[feat] 유저 인증을 위한 jwt 도입

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security")
 
     // jwt
-    implementation("io.jsonwebtoken:jjwt:0.9.1")
+    implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+    implementation("io.jsonwebtoken:jjwt-impl:0.11.5")
+    implementation("io.jsonwebtoken:jjwt-jackson:0.11.5")
 }
 
 kotlin {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,9 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     implementation("org.springframework.boot:spring-boot-starter-security")
+
+    // jwt
+    implementation("io.jsonwebtoken:jjwt:0.9.1")
 }
 
 kotlin {

--- a/src/main/kotlin/com/example/chekitoki/config/auth/CustomUserDetails.kt
+++ b/src/main/kotlin/com/example/chekitoki/config/auth/CustomUserDetails.kt
@@ -9,7 +9,7 @@ class CustomUserDetails (
 ) : UserDetails {
     override fun getAuthorities() = listOf(GrantedAuthority { user.role.value })
     override fun getPassword(): String  = user.password
-    override fun getUsername(): String = user.email
+    override fun getUsername(): String = user.userId
 
     override fun isAccountNonExpired() = true
     override fun isAccountNonLocked() = true

--- a/src/main/kotlin/com/example/chekitoki/config/auth/CustomUserDetails.kt
+++ b/src/main/kotlin/com/example/chekitoki/config/auth/CustomUserDetails.kt
@@ -1,0 +1,18 @@
+package com.example.chekitoki.config.auth
+
+import com.example.chekitoki.domain.user.model.User
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.userdetails.UserDetails
+
+class CustomUserDetails (
+    private val user: User
+) : UserDetails {
+    override fun getAuthorities() = listOf(GrantedAuthority { user.role.value })
+    override fun getPassword(): String  = user.password
+    override fun getUsername(): String = user.email
+
+    override fun isAccountNonExpired() = true
+    override fun isAccountNonLocked() = true
+    override fun isCredentialsNonExpired() = true
+    override fun isEnabled() = true
+}

--- a/src/main/kotlin/com/example/chekitoki/config/auth/CustomUserDetailsService.kt
+++ b/src/main/kotlin/com/example/chekitoki/config/auth/CustomUserDetailsService.kt
@@ -1,0 +1,16 @@
+package com.example.chekitoki.config.auth
+
+import com.example.chekitoki.domain.user.service.UserStore
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.stereotype.Service
+
+@Service
+class CustomUserDetailsService(
+    private val userStore: UserStore,
+) : UserDetailsService {
+    override fun loadUserByUsername(username: String): UserDetails {
+        val user = userStore.getByEmail(username)
+        return CustomUserDetails(user)
+    }
+}

--- a/src/main/kotlin/com/example/chekitoki/config/auth/CustomUserDetailsService.kt
+++ b/src/main/kotlin/com/example/chekitoki/config/auth/CustomUserDetailsService.kt
@@ -10,7 +10,7 @@ class CustomUserDetailsService(
     private val userStore: UserStore,
 ) : UserDetailsService {
     override fun loadUserByUsername(username: String): UserDetails {
-        val user = userStore.getByEmail(username)
+        val user = userStore.getByUserId(username)
         return CustomUserDetails(user)
     }
 }

--- a/src/main/kotlin/com/example/chekitoki/config/auth/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/example/chekitoki/config/auth/jwt/JwtAuthenticationFilter.kt
@@ -1,0 +1,47 @@
+package com.example.chekitoki.config.auth.jwt
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.core.userdetails.User
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+@Component
+class JwtAuthenticationFilter(
+    private val tokenProvider: TokenProvider,
+) : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val token = resolveToken(request)
+        if (token != null && tokenProvider.validateToken(token)) {
+            val authentication = getAuthentication(token)
+            SecurityContextHolder.getContext().authentication = authentication
+        }
+        filterChain.doFilter(request, response)
+    }
+
+    private fun resolveToken(request: HttpServletRequest): String? {
+        val bearerToken: String? = request.getHeader("Authorization")
+        return if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            bearerToken.substring(7)
+        } else null
+    }
+
+    private fun getAuthentication(token: String): Authentication {
+        val claims = tokenProvider.getClaims(token)
+        val username = claims.subject
+        val roles = claims["role"] as List<String>
+
+        val authorities = roles.map { SimpleGrantedAuthority(it) }
+        val principal = User(username, "", authorities)
+        return UsernamePasswordAuthenticationToken(principal, token, authorities)
+    }
+}

--- a/src/main/kotlin/com/example/chekitoki/config/auth/jwt/TokenProvider.kt
+++ b/src/main/kotlin/com/example/chekitoki/config/auth/jwt/TokenProvider.kt
@@ -1,0 +1,55 @@
+package com.example.chekitoki.config.auth.jwt
+
+import io.jsonwebtoken.Claims
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.core.Authentication
+import org.springframework.stereotype.Component
+import java.util.*
+
+@Component
+class TokenProvider(
+    @Value("\${spring.security.auth.secret}")
+    private val secretKey: String,
+) {
+    private val key = Keys.hmacShaKeyFor(secretKey.toByteArray())
+
+    companion object {
+        const val ACCESS_TOKEN_EXPIRE_LENGTH = 1000L * 60 * 60 // 1H
+        const val REFRESH_TOKEN_EXPIRE_LENGTH = 1000L * 60 * 60 * 24 * 7 // 7D
+        const val ACCESS_TOKEN = "access-token"
+        const val REFRESH_TOKEN = "refresh-token"
+    }
+
+
+    fun generateToken(authentication: Authentication, isAccess: Boolean): String {
+        val now = Date()
+        val expirationDate = Date(now.time + if (isAccess) ACCESS_TOKEN_EXPIRE_LENGTH else REFRESH_TOKEN_EXPIRE_LENGTH)
+
+        val username = authentication.name
+        val role = authentication.authorities
+
+        return Jwts.builder()
+            .setSubject(username)
+            .claim("role", role.map { it.authority })
+            .setIssuedAt(now)
+            .setExpiration(expirationDate)
+            .signWith(key)
+            .compact()
+    }
+
+    fun validateToken(token: String): Boolean {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token)
+            return true
+        } catch (e: Exception) {
+            return false
+        }
+    }
+
+    fun getClaims(token: String): Claims {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).body
+            ?: throw RuntimeException("Token is not valid")
+    }
+}

--- a/src/main/kotlin/com/example/chekitoki/config/auth/jwt/exception/JwtAccessDeniedHandler.kt
+++ b/src/main/kotlin/com/example/chekitoki/config/auth/jwt/exception/JwtAccessDeniedHandler.kt
@@ -1,0 +1,28 @@
+package com.example.chekitoki.config.auth.jwt.exception
+
+import com.example.chekitoki.api.response.ApiResponse
+import com.example.chekitoki.api.response.ResponseCode
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.web.access.AccessDeniedHandler
+import org.springframework.stereotype.Component
+
+@Component
+class JwtAccessDeniedHandler(
+    private val objectMapper: ObjectMapper,
+) : AccessDeniedHandler {
+    override fun handle(
+        request: HttpServletRequest?,
+        response: HttpServletResponse?,
+        accessDeniedException: AccessDeniedException?
+    ) {
+        val apiResponse: ApiResponse<*> = ApiResponse.exceptionError(ResponseCode.FORBIDDEN, accessDeniedException?.localizedMessage ?: "Forbidden")
+
+        response?.status = HttpServletResponse.SC_FORBIDDEN
+        response?.contentType = "application/json"
+        response?.characterEncoding = "UTF-8"
+        response?.writer?.write(objectMapper.writeValueAsString(apiResponse))
+    }
+}

--- a/src/main/kotlin/com/example/chekitoki/config/auth/jwt/exception/JwtAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/com/example/chekitoki/config/auth/jwt/exception/JwtAuthenticationEntryPoint.kt
@@ -1,0 +1,28 @@
+package com.example.chekitoki.config.auth.jwt.exception
+
+import com.example.chekitoki.api.response.ApiResponse
+import com.example.chekitoki.api.response.ResponseCode
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.stereotype.Component
+
+@Component
+class JwtAuthenticationEntryPoint(
+    private val objectMapper: ObjectMapper,
+) : AuthenticationEntryPoint {
+    override fun commence(
+        request: HttpServletRequest?,
+        response: HttpServletResponse?,
+        authException: AuthenticationException?
+    ) {
+        val apiResponse: ApiResponse<*> = ApiResponse.exceptionError(ResponseCode.BAD_REQUEST, authException?.localizedMessage ?: "Unauthorized")
+
+        response?.status = HttpServletResponse.SC_BAD_REQUEST
+        response?.contentType = "application/json"
+        response?.characterEncoding = "UTF-8"
+        response?.writer?.write(objectMapper.writeValueAsString(apiResponse))
+    }
+}

--- a/src/main/kotlin/com/example/chekitoki/domain/token/model/RefreshToken.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/token/model/RefreshToken.kt
@@ -16,5 +16,5 @@ class RefreshToken(
     @JoinColumn(name = "user_id")
     val user: User = user
 
-    val token: String = token
+    var token: String = token
 }

--- a/src/main/kotlin/com/example/chekitoki/domain/token/model/RefreshToken.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/token/model/RefreshToken.kt
@@ -1,0 +1,20 @@
+package com.example.chekitoki.domain.token.model
+
+import com.example.chekitoki.domain.user.model.User
+import jakarta.persistence.*
+
+@Entity
+class RefreshToken(
+    user: User,
+    token: String,
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    val user: User = user
+
+    val token: String = token
+}

--- a/src/main/kotlin/com/example/chekitoki/domain/token/repository/RefreshTokenRepository.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/token/repository/RefreshTokenRepository.kt
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository
 @Repository
 interface RefreshTokenRepository : JpaRepository<RefreshToken, Long> {
     fun findByToken(token: String): RefreshToken?
+    fun deleteByToken(token: String)
 }

--- a/src/main/kotlin/com/example/chekitoki/domain/token/repository/RefreshTokenRepository.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/token/repository/RefreshTokenRepository.kt
@@ -1,0 +1,10 @@
+package com.example.chekitoki.domain.token.repository
+
+import com.example.chekitoki.domain.token.model.RefreshToken
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface RefreshTokenRepository : JpaRepository<RefreshToken, Long> {
+    fun findByToken(token: String): RefreshToken?
+}

--- a/src/main/kotlin/com/example/chekitoki/domain/token/repository/RefreshTokenStore.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/token/repository/RefreshTokenStore.kt
@@ -1,0 +1,25 @@
+package com.example.chekitoki.domain.token.repository
+
+import com.example.chekitoki.api.exception.BusinessException
+import com.example.chekitoki.api.response.ResponseCode
+import com.example.chekitoki.domain.token.model.RefreshToken
+import com.example.chekitoki.domain.user.model.User
+import org.springframework.stereotype.Service
+
+@Service
+class RefreshTokenStore(
+    private val refreshTokenRepository: RefreshTokenRepository
+) {
+    fun save(token: RefreshToken) {
+        refreshTokenRepository.save(token)
+    }
+
+    fun getByToken(token: String): RefreshToken {
+        return refreshTokenRepository.findByToken(token)
+            ?: throw BusinessException(ResponseCode.NOT_FOUND, "RefreshToken not found.")
+    }
+
+    fun deleteByToken(token: String) {
+        refreshTokenRepository.deleteByToken(token)
+    }
+}

--- a/src/main/kotlin/com/example/chekitoki/domain/user/controller/AuthenticationController.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/controller/AuthenticationController.kt
@@ -1,0 +1,34 @@
+package com.example.chekitoki.domain.user.controller
+
+import com.example.chekitoki.domain.user.dto.UserRequestDto
+import com.example.chekitoki.domain.user.dto.UserResponseDto
+import com.example.chekitoki.domain.user.service.AuthenticationService
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/auth")
+class AuthenticationController (
+    private val authenticationService: AuthenticationService,
+) {
+    @PostMapping("/login")
+    fun login(
+        @RequestBody request: UserRequestDto.Login,
+    ) : UserResponseDto {
+        return authenticationService.login(request.toInfo()).toResponseDetail()
+    }
+
+    @DeleteMapping("/logout")
+    fun logout(
+        @AuthenticationPrincipal userDetails: UserDetails,
+    ) {
+        // TODO: 로그아웃한 유저의 access token 블랙리스트 추가
+        authenticationService.logout(userDetails)
+    }
+
+    @PatchMapping("/reissue")
+    fun reissue() {
+        authenticationService.reissue()
+    }
+}

--- a/src/main/kotlin/com/example/chekitoki/domain/user/dto/UserInfo.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/dto/UserInfo.kt
@@ -4,11 +4,12 @@ import com.example.chekitoki.domain.user.model.User
 
 class UserInfo {
     data class Login(
-        val email: String,
+        val userId: String,
         val password: String,
     )
 
     data class Create(
+        val userId: String,
         val email: String,
         val name: String,
         val password: String,
@@ -27,24 +28,27 @@ class UserInfo {
 
     data class Response(
         val id: Long,
+        val userId: String,
         val email: String,
         val name: String,
     ) {
         constructor(user: User): this(
             id = user.id,
+            userId = user.userId,
             email = user.email,
             name = user.name,
         )
 
         fun toResponseDetail() = UserResponseDto.Detail(
             id = id,
+            userId = userId,
             email = email,
             name = name,
         )
 
         fun toResponseSummary() = UserResponseDto.Summary(
             id = id,
-            email = email,
+            userId = userId,
             name = name,
         )
     }

--- a/src/main/kotlin/com/example/chekitoki/domain/user/dto/UserRequestDto.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/dto/UserRequestDto.kt
@@ -2,21 +2,23 @@ package com.example.chekitoki.domain.user.dto
 
 class UserRequestDto {
     data class Login(
-        val email: String,
+        val userId: String,
         val password: String,
     ) {
         fun toInfo() = UserInfo.Login(
-            email = email,
+            userId = userId,
             password = password,
         )
     }
 
     data class Create(
+        val userId: String,
         val email: String,
         val name: String,
         val password: String,
     ) {
         fun toInfo() = UserInfo.Create(
+            userId = userId,
             email = email,
             name = name,
             password = password,

--- a/src/main/kotlin/com/example/chekitoki/domain/user/dto/UserResponseDto.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/dto/UserResponseDto.kt
@@ -1,15 +1,17 @@
 package com.example.chekitoki.domain.user.dto
 
 sealed class UserResponseDto {
-    data class Summary(
+    data class Detail(
         val id: Long,
+        val userId: String,
         val email: String,
         val name: String,
     ) : UserResponseDto()
 
-    data class Detail(
+    data class Summary(
         val id: Long,
-        val email: String,
+        val userId: String,
         val name: String,
     ) : UserResponseDto()
+
 }

--- a/src/main/kotlin/com/example/chekitoki/domain/user/model/Role.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/model/Role.kt
@@ -1,7 +1,7 @@
 package com.example.chekitoki.domain.user.model
 
 enum class Role(
-    value: String
+    val value: String
 ) {
     USER("ROLE_USER"),
     ADMIN("ROLE_ADMIN"),

--- a/src/main/kotlin/com/example/chekitoki/domain/user/model/Role.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/model/Role.kt
@@ -1,0 +1,8 @@
+package com.example.chekitoki.domain.user.model
+
+enum class Role(
+    value: String
+) {
+    USER("ROLE_USER"),
+    ADMIN("ROLE_ADMIN"),
+}

--- a/src/main/kotlin/com/example/chekitoki/domain/user/model/User.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/model/User.kt
@@ -30,11 +30,23 @@ class User (
 
     var deleted: Boolean = false
 
+    var refreshToken: String? = null
+
+    var role: Role = Role.USER
+
     fun updateProfile(name: String) {
         this.name = name
     }
 
     fun updatePassword(password: String) {
         this.password = password
+    }
+
+    fun updateRefreshToken(refreshToken: String) {
+        this.refreshToken = refreshToken
+    }
+
+    fun updateRole(role: Role) {
+        this.role = role
     }
 }

--- a/src/main/kotlin/com/example/chekitoki/domain/user/model/User.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/model/User.kt
@@ -15,6 +15,7 @@ import org.hibernate.annotations.Where
 @SQLDelete(sql = "UPDATE user SET deleted = true WHERE id = ?")
 @SQLRestriction("deleted = false")
 class User (
+    userId: String,
     email: String,
     name: String,
     password: String,
@@ -22,7 +23,9 @@ class User (
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0
 
-    val email: String = email
+    val userId: String = userId
+
+    var email: String = email
 
     var name: String = name
 
@@ -33,6 +36,10 @@ class User (
     var refreshToken: String? = null
 
     var role: Role = Role.USER
+
+    fun updateEmail(email: String) {
+        this.email = email
+    }
 
     fun updateProfile(name: String) {
         this.name = name

--- a/src/main/kotlin/com/example/chekitoki/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/repository/UserRepository.kt
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository
 @Repository
 interface UserRepository : JpaRepository<User, Long> {
     fun findByEmail(email: String): User?
+    fun findByUserId(userId: String): User?
 }

--- a/src/main/kotlin/com/example/chekitoki/domain/user/repository/UserStoreImpl.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/repository/UserStoreImpl.kt
@@ -18,6 +18,11 @@ class UserStoreImpl(
             .orElseThrow { NoSuchUserException("$id 에 대한 회원 정보가 존재하지 않습니다.") }
     }
 
+    override fun getByUserId(userId: String): User {
+        return userRepository.findByUserId(userId)
+            ?: throw NoSuchUserException("$userId 에 대한 회원 정보가 존재하지 않습니다.")
+    }
+
     override fun getByEmail(email: String): User {
         return userRepository.findByEmail(email)
             ?: throw NoSuchUserException("$email 에 대한 회원 정보가 존재하지 않습니다.")

--- a/src/main/kotlin/com/example/chekitoki/domain/user/repository/UserStoreImpl.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/repository/UserStoreImpl.kt
@@ -18,6 +18,11 @@ class UserStoreImpl(
             .orElseThrow { NoSuchUserException("$id 에 대한 회원 정보가 존재하지 않습니다.") }
     }
 
+    override fun getByEmail(email: String): User {
+        return userRepository.findByEmail(email)
+            ?: throw NoSuchUserException("$email 에 대한 회원 정보가 존재하지 않습니다.")
+    }
+
     override fun save(user: User): User {
         return userRepository.save(user)
     }

--- a/src/main/kotlin/com/example/chekitoki/domain/user/service/AuthenticationService.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/service/AuthenticationService.kt
@@ -1,0 +1,82 @@
+package com.example.chekitoki.domain.user.service
+
+import com.example.chekitoki.config.auth.jwt.TokenProvider
+import com.example.chekitoki.domain.token.model.RefreshToken
+import com.example.chekitoki.domain.token.repository.RefreshTokenStore
+import com.example.chekitoki.domain.user.dto.UserInfo
+import com.example.chekitoki.utils.CookieUtils
+import io.jsonwebtoken.Claims
+import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class AuthenticationService(
+    private val authenticationManager: AuthenticationManager,
+    private val tokenStore: RefreshTokenStore,
+    private val tokenProvider: TokenProvider,
+    private val userStore: UserStore,
+) {
+    @Transactional
+    fun login(info: UserInfo.Login): UserInfo.Response {
+        val authentication = authenticate(info.userId, info.password)
+
+        val accessToken = tokenProvider.generateToken(authentication, true)
+        val refreshToken = tokenProvider.generateToken(authentication, false)
+
+        val user = userStore.getByUserId(info.userId)
+        tokenStore.save(RefreshToken(user, refreshToken))
+
+        addCookies(accessToken, refreshToken)
+
+        return UserInfo.Response(user)
+    }
+
+    @Transactional
+    fun logout(userDetails: UserDetails) {
+        val accessToken = CookieUtils.getCookie(TokenProvider.ACCESS_TOKEN)
+        val refreshToken = CookieUtils.getCookie(TokenProvider.REFRESH_TOKEN)
+
+        tokenStore.deleteByToken(refreshToken.value)
+
+        // TODO: 로그아웃한 유저의 access token 블랙리스트 추가
+        CookieUtils.deleteCookie(accessToken)
+        CookieUtils.deleteCookie(refreshToken)
+    }
+
+    @Transactional
+    fun reissue() {
+        val refreshToken = (CookieUtils.getCookie(TokenProvider.REFRESH_TOKEN) ?: throw RuntimeException("Refresh token is not found")).value
+
+        if (!tokenProvider.validateToken(refreshToken)) {
+            throw RuntimeException("Refresh token is not valid")
+        }
+
+        val claims = tokenProvider.getClaims(refreshToken)
+        val user = userStore.getByUserId(claims.subject)
+        val roles = (claims["role"] as List<String>).map { SimpleGrantedAuthority(it) }
+
+        val authentication = UsernamePasswordAuthenticationToken(user.userId, null, roles)
+
+        val newAccessToken = tokenProvider.generateToken(authentication, true)
+        val newRefreshToken = tokenProvider.generateToken(authentication, false)
+
+        tokenStore.getByToken(refreshToken).token = newRefreshToken
+
+        addCookies(newAccessToken, newRefreshToken)
+    }
+
+    private fun authenticate(username: String, password: String): Authentication {
+        val authenticationToken = UsernamePasswordAuthenticationToken(username, password)
+        return authenticationManager.authenticate(authenticationToken)
+    }
+
+    private fun addCookies(accessToken: String, refreshToken: String) {
+        CookieUtils.addCookie(TokenProvider.ACCESS_TOKEN, accessToken, TokenProvider.ACCESS_TOKEN_EXPIRE_LENGTH.toInt())
+        CookieUtils.addCookie(TokenProvider.REFRESH_TOKEN, refreshToken, TokenProvider.REFRESH_TOKEN_EXPIRE_LENGTH.toInt())
+    }
+}

--- a/src/main/kotlin/com/example/chekitoki/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/service/UserService.kt
@@ -6,12 +6,14 @@ import com.example.chekitoki.domain.user.dto.UserResponseDto
 import com.example.chekitoki.domain.user.exception.InvalidPasswordException
 import com.example.chekitoki.domain.user.model.User
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class UserService(
     private val userStore: UserStore,
     private val encoder: PasswordEncoderWrapper
 ) {
+    @Transactional
     fun createUser(info: UserInfo.Create): UserInfo.Response {
         val user = userStore.save(User(info.userId, info.email, info.name, encoder.encode(info.password)))
         return UserInfo.Response(user)
@@ -22,6 +24,7 @@ class UserService(
         return UserInfo.Response(user)
     }
 
+    @Transactional
     fun updateProfile(info: UserInfo.UpdateProfile): UserInfo.Response {
         val user = userStore.getById(info.id)
 
@@ -30,6 +33,7 @@ class UserService(
         return UserInfo.Response(userStore.save(user))
     }
 
+    @Transactional
     fun updatePassword(info: UserInfo.UpdatePassword) {
         val user = userStore.getById(info.id)
 
@@ -39,6 +43,7 @@ class UserService(
         userStore.save(user)
     }
 
+    @Transactional
     fun deleteUser(id: Long) {
         userStore.deleteById(id)
     }

--- a/src/main/kotlin/com/example/chekitoki/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/service/UserService.kt
@@ -13,7 +13,7 @@ class UserService(
     private val encoder: PasswordEncoderWrapper
 ) {
     fun createUser(info: UserInfo.Create): UserInfo.Response {
-        val user = userStore.save(User(info.email, info.name, encoder.encode(info.password)))
+        val user = userStore.save(User(info.userId, info.email, info.name, encoder.encode(info.password)))
         return UserInfo.Response(user)
     }
 

--- a/src/main/kotlin/com/example/chekitoki/domain/user/service/UserStore.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/service/UserStore.kt
@@ -5,6 +5,7 @@ import com.example.chekitoki.domain.user.model.User
 interface UserStore {
     fun findByEmail(email: String): User?
     fun getById(id: Long): User
+    fun getByUserId(userId: String): User
     fun getByEmail(email: String): User
     fun save(user: User): User
     fun deleteById(id: Long)

--- a/src/main/kotlin/com/example/chekitoki/domain/user/service/UserStore.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/service/UserStore.kt
@@ -5,6 +5,7 @@ import com.example.chekitoki.domain.user.model.User
 interface UserStore {
     fun findByEmail(email: String): User?
     fun getById(id: Long): User
+    fun getByEmail(email: String): User
     fun save(user: User): User
     fun deleteById(id: Long)
 }

--- a/src/main/kotlin/com/example/chekitoki/utils/CookieUtils.kt
+++ b/src/main/kotlin/com/example/chekitoki/utils/CookieUtils.kt
@@ -1,0 +1,38 @@
+package com.example.chekitoki.utils
+
+import com.example.chekitoki.api.exception.BusinessException
+import com.example.chekitoki.api.response.ResponseCode
+import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+
+object CookieUtils {
+    fun findCookie(name: String): Cookie? {
+        val request = RequestUtils.getHttpServletRequest()
+        val cookies = request.cookies
+        return cookies?.find { it.name == name }
+    }
+
+    fun getCookie(name: String): Cookie {
+        val request = RequestUtils.getHttpServletRequest()
+        val cookies = request.cookies
+        return cookies?.find { it.name == name } ?: throw BusinessException(ResponseCode.NOT_FOUND, "No cookie found. name = $name")
+    }
+
+    fun addCookie(name: String, value: String, maxAge: Int) {
+        val response = RequestUtils.getHttpServletResponse()
+        val cookie = Cookie(name, value)
+        cookie.path = "/"
+        cookie.isHttpOnly = true
+        cookie.maxAge = maxAge
+        response.addCookie(cookie)
+    }
+
+    fun deleteCookie(cookie: Cookie) {
+        val response = RequestUtils.getHttpServletResponse()
+        cookie.value = ""
+        cookie.path = "/"
+        cookie.maxAge = 0
+        response.addCookie(cookie)
+    }
+}

--- a/src/main/kotlin/com/example/chekitoki/utils/RequestUtils.kt
+++ b/src/main/kotlin/com/example/chekitoki/utils/RequestUtils.kt
@@ -1,0 +1,17 @@
+package com.example.chekitoki.utils
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+
+object RequestUtils {
+    fun getHttpServletRequest(): HttpServletRequest {
+        return (RequestContextHolder.getRequestAttributes() as ServletRequestAttributes).request
+    }
+
+    fun getHttpServletResponse(): HttpServletResponse {
+        return (RequestContextHolder.getRequestAttributes() as ServletRequestAttributes).response
+            ?: throw IllegalStateException("HttpServletResponse is not available.")
+    }
+}


### PR DESCRIPTION
close #9

- JWT 구현 코드 작성
  - 유저 권한 관리를 위한 Role enum 클래스 추가
  - RefreshToken 엔티티 구현
  - 유저 엔티티 내 userId 필드 추가
- 인증 관련 API 구현
  -  로그인, 로그아웃, 토큰 재발급을 수행하는 AuthenticationController 구현