### PR TITLE
[test/feat] 유저 테스트코드 작성

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,16 +38,26 @@ dependencies {
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
 
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-
     implementation("org.springframework.boot:spring-boot-starter-security")
 
     // jwt
     implementation("io.jsonwebtoken:jjwt-api:0.11.5")
     implementation("io.jsonwebtoken:jjwt-impl:0.11.5")
     implementation("io.jsonwebtoken:jjwt-jackson:0.11.5")
+
+    // test
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+
+    testImplementation("io.kotest:kotest-runner-junit5:5.5.4")
+    testImplementation("io.kotest:kotest-assertions-core:5.5.4")
+    testImplementation("io.kotest:kotest-framework-engine:5.5.4")
+    testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.2")
+
+    testImplementation("io.mockk:mockk:1.13.5")
+
+    // spring rest docs
+    testImplementation("org.springframework.restdocs-mockmvc:2.0.6.RELEASE")
+    testImplementation("org.springframework.restdocs-asciidoctor:2.0.6.RELEASE")
 }
 
 kotlin {

--- a/src/main/kotlin/com/example/chekitoki/ChekitokiApplication.kt
+++ b/src/main/kotlin/com/example/chekitoki/ChekitokiApplication.kt
@@ -4,7 +4,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
-@EnableJpaAuditing
 @SpringBootApplication
 class ChekitokiApplication
 

--- a/src/main/kotlin/com/example/chekitoki/api/response/ApiResponse.kt
+++ b/src/main/kotlin/com/example/chekitoki/api/response/ApiResponse.kt
@@ -3,13 +3,13 @@ package com.example.chekitoki.api.response
 import org.springframework.validation.BindingResult
 
 class ApiResponse<T>(
-    val code: ResponseCode,
+    val code: Int,
     val message: String,
     val data: T?,
 ) {
     companion object {
         fun exceptionError(code: ResponseCode, message: String): ApiResponse<*> {
-            return ApiResponse(code, message, null)
+            return ApiResponse(code.code, message, null)
         }
 
         fun fieldError(bindingResult: BindingResult): ApiResponse<HashMap<String, String>> {
@@ -19,7 +19,7 @@ class ApiResponse<T>(
                 errors[error.field] = error.defaultMessage ?: ""
             }
 
-            return ApiResponse(ResponseCode.BAD_REQUEST, "Invalid request", errors)
+            return ApiResponse(ResponseCode.BAD_REQUEST.code, "Invalid request", errors)
         }
     }
 }

--- a/src/main/kotlin/com/example/chekitoki/api/response/ResponseCode.kt
+++ b/src/main/kotlin/com/example/chekitoki/api/response/ResponseCode.kt
@@ -6,6 +6,7 @@ enum class ResponseCode(
 ) {
     SUCCESS(200, "success"),
     BAD_REQUEST(400, "bad request"),
+    UNAUTHORIZED(401, "unauthorized"),
     FORBIDDEN(403, "forbidden"),
     NOT_FOUND(404, "not found"),
     METHOD_NOT_SUPPORTED(405, "method not supported"),

--- a/src/main/kotlin/com/example/chekitoki/config/JpaAuditingConfig.kt
+++ b/src/main/kotlin/com/example/chekitoki/config/JpaAuditingConfig.kt
@@ -1,0 +1,9 @@
+package com.example.chekitoki.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+
+@Configuration
+@EnableJpaAuditing
+class JpaAuditingConfig {
+}

--- a/src/main/kotlin/com/example/chekitoki/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/example/chekitoki/config/SecurityConfig.kt
@@ -1,6 +1,8 @@
 package com.example.chekitoki.config
 
 import com.example.chekitoki.config.auth.jwt.JwtAuthenticationFilter
+import com.example.chekitoki.config.auth.jwt.exception.JwtAccessDeniedHandler
+import com.example.chekitoki.config.auth.jwt.exception.JwtAuthenticationEntryPoint
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.authentication.AuthenticationManager
@@ -19,6 +21,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableWebSecurity
 class SecurityConfig (
     private val jwtAuthenticationFilter: JwtAuthenticationFilter,
+    private val jwtAccessDeniedHandler: JwtAccessDeniedHandler,
+    private val jwtAuthenticationEntryPoint: JwtAuthenticationEntryPoint,
     private val userDetailsService: UserDetailsService,
 ) {
     @Bean
@@ -34,6 +38,10 @@ class SecurityConfig (
                 request
                     .requestMatchers("/api/**").permitAll()
                     .anyRequest().authenticated()
+            }
+            .exceptionHandling {
+                it.accessDeniedHandler(jwtAccessDeniedHandler)
+                    .authenticationEntryPoint(jwtAuthenticationEntryPoint)
             }
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
 

--- a/src/main/kotlin/com/example/chekitoki/config/auth/jwt/TokenProvider.kt
+++ b/src/main/kotlin/com/example/chekitoki/config/auth/jwt/TokenProvider.kt
@@ -1,5 +1,7 @@
 package com.example.chekitoki.config.auth.jwt
 
+import com.example.chekitoki.api.exception.BusinessException
+import com.example.chekitoki.api.response.ResponseCode
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.security.Keys
@@ -22,6 +24,7 @@ class TokenProvider(
         const val REFRESH_TOKEN = "refresh-token"
     }
 
+    class InvalidTokenException : BusinessException(ResponseCode.UNAUTHORIZED, "Token is not valid")
 
     fun generateToken(authentication: Authentication, isAccess: Boolean): String {
         val now = Date()
@@ -40,12 +43,16 @@ class TokenProvider(
     }
 
     fun validateToken(token: String): Boolean {
-        try {
+        return try {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token)
-            return true
+            true
         } catch (e: Exception) {
-            return false
+            false
         }
+    }
+
+    fun validateTokenOrThrow(token: String) {
+        if (!validateToken(token)) throw InvalidTokenException()
     }
 
     fun getClaims(token: String): Claims {

--- a/src/main/kotlin/com/example/chekitoki/domain/user/controller/AuthenticationController.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/controller/AuthenticationController.kt
@@ -24,7 +24,7 @@ class AuthenticationController (
         @AuthenticationPrincipal userDetails: UserDetails,
     ) {
         // TODO: 로그아웃한 유저의 access token 블랙리스트 추가
-        authenticationService.logout(userDetails)
+        authenticationService.logout(userDetails.username)
     }
 
     @PatchMapping("/reissue")

--- a/src/main/kotlin/com/example/chekitoki/domain/user/controller/AuthenticationController.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/controller/AuthenticationController.kt
@@ -3,6 +3,7 @@ package com.example.chekitoki.domain.user.controller
 import com.example.chekitoki.domain.user.dto.UserRequestDto
 import com.example.chekitoki.domain.user.dto.UserResponseDto
 import com.example.chekitoki.domain.user.service.AuthenticationService
+import jakarta.validation.Valid
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.web.bind.annotation.*
@@ -14,7 +15,7 @@ class AuthenticationController (
 ) {
     @PostMapping("/login")
     fun login(
-        @RequestBody request: UserRequestDto.Login,
+        @Valid @RequestBody request: UserRequestDto.Login,
     ) : UserResponseDto {
         return authenticationService.login(request.toInfo()).toResponseDetail()
     }

--- a/src/main/kotlin/com/example/chekitoki/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/controller/UserController.kt
@@ -3,6 +3,8 @@ package com.example.chekitoki.domain.user.controller
 import com.example.chekitoki.domain.user.dto.UserRequestDto
 import com.example.chekitoki.domain.user.dto.UserResponseDto
 import com.example.chekitoki.domain.user.service.UserService
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.web.bind.annotation.*
 
 @RestController
@@ -28,23 +30,25 @@ class UserController (
 
     @PatchMapping("/update/profile")
     fun updateUserProfile(
+        @AuthenticationPrincipal userDetails: UserDetails,
         @RequestBody request: UserRequestDto.UpdateProfile,
     ): UserResponseDto {
-        val response = userService.updateProfile(request.toInfo())
+        val response = userService.updateProfile(userDetails.username, request.toInfo())
         return response.toResponseDetail()
     }
 
     @PatchMapping("/update/password")
     fun updateUserPassword(
+        @AuthenticationPrincipal userDetails: UserDetails,
         @RequestBody request: UserRequestDto.UpdatePassword,
     ) {
-        return userService.updatePassword(request.toInfo())
+        return userService.updatePassword(userDetails.username, request.toInfo())
     }
 
-    @DeleteMapping("/{userId}")
+    @DeleteMapping
     fun deleteUser(
-        @PathVariable userId: Long,
+        @AuthenticationPrincipal userDetails: UserDetails,
     ) {
-        userService.deleteUser(userId)
+        userService.deleteUser(userDetails.username)
     }
 }

--- a/src/main/kotlin/com/example/chekitoki/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/controller/UserController.kt
@@ -3,6 +3,7 @@ package com.example.chekitoki.domain.user.controller
 import com.example.chekitoki.domain.user.dto.UserRequestDto
 import com.example.chekitoki.domain.user.dto.UserResponseDto
 import com.example.chekitoki.domain.user.service.UserService
+import jakarta.validation.Valid
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.web.bind.annotation.*
@@ -14,7 +15,7 @@ class UserController (
 ) {
     @PostMapping
     fun createUser(
-        @RequestBody request: UserRequestDto.Create,
+        @Valid @RequestBody request: UserRequestDto.Create,
     ): UserResponseDto {
         val response = userService.createUser(request.toInfo())
         return response.toResponseDetail()
@@ -31,7 +32,7 @@ class UserController (
     @PatchMapping("/update/profile")
     fun updateUserProfile(
         @AuthenticationPrincipal userDetails: UserDetails,
-        @RequestBody request: UserRequestDto.UpdateProfile,
+        @Valid @RequestBody request: UserRequestDto.UpdateProfile,
     ): UserResponseDto {
         val response = userService.updateProfile(userDetails.username, request.toInfo())
         return response.toResponseDetail()
@@ -40,7 +41,7 @@ class UserController (
     @PatchMapping("/update/password")
     fun updateUserPassword(
         @AuthenticationPrincipal userDetails: UserDetails,
-        @RequestBody request: UserRequestDto.UpdatePassword,
+        @Valid @RequestBody request: UserRequestDto.UpdatePassword,
     ) {
         return userService.updatePassword(userDetails.username, request.toInfo())
     }

--- a/src/main/kotlin/com/example/chekitoki/domain/user/dto/UserInfo.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/dto/UserInfo.kt
@@ -16,12 +16,10 @@ class UserInfo {
     )
 
     data class UpdateProfile(
-        val id: Long,
         val name: String,
     )
 
     data class UpdatePassword(
-        val id: Long,
         val oldPassword: String,
         val newPassword: String,
     )

--- a/src/main/kotlin/com/example/chekitoki/domain/user/dto/UserRequestDto.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/dto/UserRequestDto.kt
@@ -1,45 +1,76 @@
 package com.example.chekitoki.domain.user.dto
 
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+
 class UserRequestDto {
+    // TODO: !!를 사용하지 않고, NotBlank를 처리할 수 있는 방안 모색
+    companion object {
+        const val NAME_REGEX = "^[a-zA-Z가-힣]{2,20}$"
+        const val NAME_MESSAGE = "이름은 2~20자의 한글 또는 영문으로 이루어져야 합니다."
+
+        const val PASSWORD_REGEX = "^(?=.*[a-zA-Z])(?=.*[0-9]).{8,20}$"
+        const val PASSWORD_MESSAGE = "비밀번호는 8~20자의 영문 대소문자와 숫자로 이루어져야 합니다."
+    }
+
     data class Login(
-        val userId: String,
-        val password: String,
+        @field:NotBlank(message = "아이디를 입력해주세요.")
+        val userId: String?,
+        @field:NotBlank(message = "비밀번호를 입력해주세요.")
+        val password: String?,
     ) {
         fun toInfo() = UserInfo.Login(
-            userId = userId,
-            password = password,
+            userId = userId!!,
+            password = password!!,
         )
     }
 
     data class Create(
-        val userId: String,
-        val email: String,
-        val name: String,
-        val password: String,
+        @field:NotBlank(message = "아이디는 필수 입력값입니다.")
+        @field:Pattern(regexp = "^[a-z0-9]{5,20}$", message = "아이디는 5~20자의 영문 소문자와 숫자로 이루어져야 합니다.")
+        val userId: String?,
+        @field:NotBlank(message = "이메일은 필수 입력값입니다.")
+        @field:Pattern(regexp = "^[a-zA-Z0-9._+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z]{2,6}$", message = "이메일 형식이 올바르지 않습니다.")
+        val email: String?,
+        @field:NotBlank(message = "이름은 필수 입력값입니다.")
+        @field:Pattern(regexp = NAME_REGEX, message = NAME_MESSAGE)
+        val name: String?,
+        @field:NotBlank(message = "비밀번호는 필수 입력값입니다.")
+        @field:Pattern(regexp = PASSWORD_REGEX, message = PASSWORD_MESSAGE)
+        val password: String?,
     ) {
         fun toInfo() = UserInfo.Create(
-            userId = userId,
-            email = email,
-            name = name,
-            password = password,
+            userId = userId!!,
+            email = email!!,
+            name = name!!,
+            password = password!!,
         )
     }
 
     data class UpdateProfile(
-        val name: String,
+        @field:NotBlank(message = "이름은 필수 입력값입니다.")
+        @field:Pattern(regexp = NAME_REGEX, message = NAME_MESSAGE)
+        val name: String?,
     ) {
-        fun toInfo() = UserInfo.UpdateProfile(
-            name = name,
-        )
+        fun toInfo(): UserInfo.UpdateProfile {
+            return UserInfo.UpdateProfile(
+                name = name!!,
+            )
+        }
     }
 
     data class UpdatePassword(
-        val oldPassword: String,
-        val newPassword: String,
+        @field:NotBlank(message = "이전 비밀번호는 필수 입력값입니다.")
+        val oldPassword: String?,
+        @field:NotBlank(message = "새 비밀번호는 필수 입력값입니다.")
+        @field:Pattern(regexp = PASSWORD_REGEX, message = PASSWORD_MESSAGE)
+        val newPassword: String?,
     ) {
-        fun toInfo() = UserInfo.UpdatePassword(
-            oldPassword = oldPassword,
-            newPassword = newPassword,
-        )
+        fun toInfo(): UserInfo.UpdatePassword {
+            return UserInfo.UpdatePassword(
+                oldPassword = oldPassword!!,
+                newPassword = newPassword!!,
+            )
+        }
     }
 }

--- a/src/main/kotlin/com/example/chekitoki/domain/user/dto/UserRequestDto.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/dto/UserRequestDto.kt
@@ -26,22 +26,18 @@ class UserRequestDto {
     }
 
     data class UpdateProfile(
-        val id: Long,
         val name: String,
     ) {
         fun toInfo() = UserInfo.UpdateProfile(
-            id = id,
             name = name,
         )
     }
 
     data class UpdatePassword(
-        val id: Long,
         val oldPassword: String,
         val newPassword: String,
     ) {
         fun toInfo() = UserInfo.UpdatePassword(
-            id = id,
             oldPassword = oldPassword,
             newPassword = newPassword,
         )

--- a/src/main/kotlin/com/example/chekitoki/domain/user/dto/UserRequestDto.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/dto/UserRequestDto.kt
@@ -26,22 +26,22 @@ class UserRequestDto {
     }
 
     data class UpdateProfile(
-        val userId: Long,
+        val id: Long,
         val name: String,
     ) {
         fun toInfo() = UserInfo.UpdateProfile(
-            id = userId,
+            id = id,
             name = name,
         )
     }
 
     data class UpdatePassword(
-        val userId: Long,
+        val id: Long,
         val oldPassword: String,
         val newPassword: String,
     ) {
         fun toInfo() = UserInfo.UpdatePassword(
-            id = userId,
+            id = id,
             oldPassword = oldPassword,
             newPassword = newPassword,
         )

--- a/src/main/kotlin/com/example/chekitoki/domain/user/exception/DuplicatePasswordException.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/exception/DuplicatePasswordException.kt
@@ -1,0 +1,12 @@
+package com.example.chekitoki.domain.user.exception
+
+import com.example.chekitoki.api.exception.BusinessException
+import com.example.chekitoki.api.response.ResponseCode
+
+class DuplicatePasswordException(
+    message: String?,
+) : BusinessException(
+    ResponseCode.BAD_REQUEST,
+    message,
+) {
+}

--- a/src/main/kotlin/com/example/chekitoki/domain/user/exception/DuplicateUserException.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/exception/DuplicateUserException.kt
@@ -1,0 +1,12 @@
+package com.example.chekitoki.domain.user.exception
+
+import com.example.chekitoki.api.exception.BusinessException
+import com.example.chekitoki.api.response.ResponseCode
+
+class DuplicateUserException(
+    message: String?
+) : BusinessException(
+    ResponseCode.DUPLICATE,
+    message
+){
+}

--- a/src/main/kotlin/com/example/chekitoki/domain/user/exception/InvalidCredentialsException.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/exception/InvalidCredentialsException.kt
@@ -1,0 +1,8 @@
+package com.example.chekitoki.domain.user.exception
+
+import com.example.chekitoki.api.exception.BusinessException
+import com.example.chekitoki.api.response.ResponseCode
+
+class InvalidCredentialsException(
+    message: String?,
+) : BusinessException(ResponseCode.UNAUTHORIZED, message)

--- a/src/main/kotlin/com/example/chekitoki/domain/user/model/User.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/model/User.kt
@@ -8,7 +8,6 @@ import jakarta.persistence.Id
 import jakarta.persistence.Table
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
-import org.hibernate.annotations.Where
 
 @Entity
 @Table(name = "user")

--- a/src/main/kotlin/com/example/chekitoki/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/repository/UserRepository.kt
@@ -8,4 +8,5 @@ import org.springframework.stereotype.Repository
 interface UserRepository : JpaRepository<User, Long> {
     fun findByEmail(email: String): User?
     fun findByUserId(userId: String): User?
+    fun deleteByUserId(userId: String)
 }

--- a/src/main/kotlin/com/example/chekitoki/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/repository/UserRepository.kt
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface UserRepository : JpaRepository<User, Long> {
+    fun existsByUserId(userId: String): Boolean
     fun findByEmail(email: String): User?
     fun findByUserId(userId: String): User?
     fun deleteByUserId(userId: String)

--- a/src/main/kotlin/com/example/chekitoki/domain/user/repository/UserStoreImpl.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/repository/UserStoreImpl.kt
@@ -9,6 +9,10 @@ import org.springframework.stereotype.Component
 class UserStoreImpl(
     private val userRepository: UserRepository,
 ) : UserStore {
+    override fun existsByUserId(userId: String): Boolean {
+        return userRepository.existsByUserId(userId)
+    }
+
     override fun findByEmail(email: String): User? {
         return userRepository.findByEmail(email)
     }

--- a/src/main/kotlin/com/example/chekitoki/domain/user/repository/UserStoreImpl.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/repository/UserStoreImpl.kt
@@ -32,7 +32,7 @@ class UserStoreImpl(
         return userRepository.save(user)
     }
 
-    override fun deleteById(id: Long) {
-        userRepository.deleteById(id)
+    override fun deleteByUserId(userId: String) {
+        userRepository.deleteByUserId(userId)
     }
 }

--- a/src/main/kotlin/com/example/chekitoki/domain/user/service/AuthenticationService.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/service/AuthenticationService.kt
@@ -37,7 +37,7 @@ class AuthenticationService(
     }
 
     @Transactional
-    fun logout(userDetails: UserDetails) {
+    fun logout(userId: String) {
         val accessToken = CookieUtils.getCookie(TokenProvider.ACCESS_TOKEN)
         val refreshToken = CookieUtils.getCookie(TokenProvider.REFRESH_TOKEN)
 
@@ -50,11 +50,8 @@ class AuthenticationService(
 
     @Transactional
     fun reissue() {
-        val refreshToken = (CookieUtils.getCookie(TokenProvider.REFRESH_TOKEN) ?: throw RuntimeException("Refresh token is not found")).value
-
-        if (!tokenProvider.validateToken(refreshToken)) {
-            throw RuntimeException("Refresh token is not valid")
-        }
+        val refreshToken = CookieUtils.getCookie(TokenProvider.REFRESH_TOKEN).value
+        tokenProvider.validateTokenOrThrow(refreshToken)
 
         val claims = tokenProvider.getClaims(refreshToken)
         val user = userStore.getByUserId(claims.subject)

--- a/src/main/kotlin/com/example/chekitoki/domain/user/service/AuthenticationService.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/service/AuthenticationService.kt
@@ -4,6 +4,7 @@ import com.example.chekitoki.config.auth.jwt.TokenProvider
 import com.example.chekitoki.domain.token.model.RefreshToken
 import com.example.chekitoki.domain.token.repository.RefreshTokenStore
 import com.example.chekitoki.domain.user.dto.UserInfo
+import com.example.chekitoki.domain.user.exception.InvalidCredentialsException
 import com.example.chekitoki.utils.CookieUtils
 import io.jsonwebtoken.Claims
 import org.springframework.security.authentication.AuthenticationManager
@@ -69,7 +70,11 @@ class AuthenticationService(
 
     private fun authenticate(username: String, password: String): Authentication {
         val authenticationToken = UsernamePasswordAuthenticationToken(username, password)
-        return authenticationManager.authenticate(authenticationToken)
+        return try {
+            authenticationManager.authenticate(authenticationToken)
+        } catch (e: Exception) {
+            throw InvalidCredentialsException("아이디 또는 비밀번호가 올바르지 않습니다.")
+        }
     }
 
     private fun addCookies(accessToken: String, refreshToken: String) {

--- a/src/main/kotlin/com/example/chekitoki/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/service/UserService.kt
@@ -2,6 +2,7 @@ package com.example.chekitoki.domain.user.service
 
 import com.example.chekitoki.config.PasswordEncoderWrapper
 import com.example.chekitoki.domain.user.dto.UserInfo
+import com.example.chekitoki.domain.user.exception.DuplicateUserException
 import com.example.chekitoki.domain.user.exception.InvalidPasswordException
 import com.example.chekitoki.domain.user.model.User
 import org.springframework.stereotype.Service
@@ -14,6 +15,7 @@ class UserService(
 ) {
     @Transactional
     fun createUser(info: UserInfo.Create): UserInfo.Response {
+        validateUserId(info.userId)
         val user = userStore.save(User(info.userId, info.email, info.name, encoder.encode(info.password)))
         return UserInfo.Response(user)
     }
@@ -45,6 +47,12 @@ class UserService(
     @Transactional
     fun deleteUser(userId: String) {
         userStore.deleteByUserId(userId)
+    }
+
+    private fun validateUserId(userId: String) {
+        if (userStore.existsByUserId(userId)) {
+            throw DuplicateUserException("이미 존재하는 아이디입니다.")
+        }
     }
 
     private fun validatePasswordMatch(oldPassword: String, newPassword: String) {

--- a/src/main/kotlin/com/example/chekitoki/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/service/UserService.kt
@@ -2,6 +2,7 @@ package com.example.chekitoki.domain.user.service
 
 import com.example.chekitoki.config.PasswordEncoderWrapper
 import com.example.chekitoki.domain.user.dto.UserInfo
+import com.example.chekitoki.domain.user.exception.DuplicatePasswordException
 import com.example.chekitoki.domain.user.exception.DuplicateUserException
 import com.example.chekitoki.domain.user.exception.InvalidPasswordException
 import com.example.chekitoki.domain.user.model.User
@@ -39,6 +40,7 @@ class UserService(
         val user = userStore.getByUserId(userId)
 
         validatePasswordMatch(info.oldPassword, user.password)
+        validateDuplicatePassword(info.oldPassword, info.newPassword)
 
         user.updatePassword(encoder.encode(info.newPassword))
         userStore.save(user)
@@ -58,6 +60,12 @@ class UserService(
     private fun validatePasswordMatch(oldPassword: String, newPassword: String) {
         if (!encoder.matches(oldPassword, newPassword)) {
             throw InvalidPasswordException("비밀번호가 일치하지 않습니다.")
+        }
+    }
+
+    private fun validateDuplicatePassword(oldPassword: String, newPassword: String) {
+        if (oldPassword == newPassword) {
+            throw DuplicatePasswordException("이전 비밀번호와 동일한 비밀번호는 사용할 수 없습니다.")
         }
     }
 }

--- a/src/main/kotlin/com/example/chekitoki/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/service/UserService.kt
@@ -2,7 +2,6 @@ package com.example.chekitoki.domain.user.service
 
 import com.example.chekitoki.config.PasswordEncoderWrapper
 import com.example.chekitoki.domain.user.dto.UserInfo
-import com.example.chekitoki.domain.user.dto.UserResponseDto
 import com.example.chekitoki.domain.user.exception.InvalidPasswordException
 import com.example.chekitoki.domain.user.model.User
 import org.springframework.stereotype.Service
@@ -37,7 +36,7 @@ class UserService(
     fun updatePassword(userId: String, info: UserInfo.UpdatePassword) {
         val user = userStore.getByUserId(userId)
 
-        confirmPassword(info.oldPassword, user.password)
+        validatePasswordMatch(info.oldPassword, user.password)
 
         user.updatePassword(encoder.encode(info.newPassword))
         userStore.save(user)
@@ -48,7 +47,7 @@ class UserService(
         userStore.deleteByUserId(userId)
     }
 
-    private fun confirmPassword(oldPassword: String, newPassword: String) {
+    private fun validatePasswordMatch(oldPassword: String, newPassword: String) {
         if (!encoder.matches(oldPassword, newPassword)) {
             throw InvalidPasswordException("비밀번호가 일치하지 않습니다.")
         }

--- a/src/main/kotlin/com/example/chekitoki/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/service/UserService.kt
@@ -25,8 +25,8 @@ class UserService(
     }
 
     @Transactional
-    fun updateProfile(info: UserInfo.UpdateProfile): UserInfo.Response {
-        val user = userStore.getById(info.id)
+    fun updateProfile(userId: String, info: UserInfo.UpdateProfile): UserInfo.Response {
+        val user = userStore.getByUserId(userId)
 
         user.updateProfile(info.name)
 
@@ -34,8 +34,8 @@ class UserService(
     }
 
     @Transactional
-    fun updatePassword(info: UserInfo.UpdatePassword) {
-        val user = userStore.getById(info.id)
+    fun updatePassword(userId: String, info: UserInfo.UpdatePassword) {
+        val user = userStore.getByUserId(userId)
 
         confirmPassword(info.oldPassword, user.password)
 
@@ -44,8 +44,8 @@ class UserService(
     }
 
     @Transactional
-    fun deleteUser(id: Long) {
-        userStore.deleteById(id)
+    fun deleteUser(userId: String) {
+        userStore.deleteByUserId(userId)
     }
 
     private fun confirmPassword(oldPassword: String, newPassword: String) {

--- a/src/main/kotlin/com/example/chekitoki/domain/user/service/UserStore.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/service/UserStore.kt
@@ -8,5 +8,5 @@ interface UserStore {
     fun getByUserId(userId: String): User
     fun getByEmail(email: String): User
     fun save(user: User): User
-    fun deleteById(id: Long)
+    fun deleteByUserId(userId: String)
 }

--- a/src/main/kotlin/com/example/chekitoki/domain/user/service/UserStore.kt
+++ b/src/main/kotlin/com/example/chekitoki/domain/user/service/UserStore.kt
@@ -3,6 +3,7 @@ package com.example.chekitoki.domain.user.service
 import com.example.chekitoki.domain.user.model.User
 
 interface UserStore {
+    fun existsByUserId(userId: String): Boolean
     fun findByEmail(email: String): User?
     fun getById(id: Long): User
     fun getByUserId(userId: String): User

--- a/src/main/kotlin/com/example/chekitoki/utils/CookieUtils.kt
+++ b/src/main/kotlin/com/example/chekitoki/utils/CookieUtils.kt
@@ -3,10 +3,10 @@ package com.example.chekitoki.utils
 import com.example.chekitoki.api.exception.BusinessException
 import com.example.chekitoki.api.response.ResponseCode
 import jakarta.servlet.http.Cookie
-import jakarta.servlet.http.HttpServletRequest
-import jakarta.servlet.http.HttpServletResponse
 
 object CookieUtils {
+    class NoSuchCookieException(message: String?) : BusinessException(ResponseCode.NOT_FOUND, message)
+
     fun findCookie(name: String): Cookie? {
         val request = RequestUtils.getHttpServletRequest()
         val cookies = request.cookies
@@ -16,7 +16,8 @@ object CookieUtils {
     fun getCookie(name: String): Cookie {
         val request = RequestUtils.getHttpServletRequest()
         val cookies = request.cookies
-        return cookies?.find { it.name == name } ?: throw BusinessException(ResponseCode.NOT_FOUND, "No cookie found. name = $name")
+        return cookies?.find { it.name == name }
+            ?: throw NoSuchCookieException("No cookie found. name = $name")
     }
 
     fun addCookie(name: String, value: String, maxAge: Int) {

--- a/src/test/kotlin/com/example/chekitoki/domain/fixtures/UserFixtures.kt
+++ b/src/test/kotlin/com/example/chekitoki/domain/fixtures/UserFixtures.kt
@@ -11,7 +11,7 @@ class UserFixtures {
         const val userPassword = "asdfqwer1234"
         const val id = 1L
 
-        private const val modifiedName = "수정된 테스트"
+        const val modifiedName = "수정된 테스트"
         private const val modifiedPassword = "qwer1234asdf"
 
         private const val anotherUserId = "rnignon"
@@ -21,7 +21,8 @@ class UserFixtures {
         private const val anotherId = 2L
 
         val testUser = User(userId, userEmail, userName, userPassword)
-        val modifiedUser = User(userId, userEmail, modifiedName, modifiedPassword)
+        val modifiedProfileUser = User(userId, userEmail, modifiedName, userPassword)
+        val modifiedPasswordUser = User(userId, userEmail, userName, modifiedPassword)
         val anotherUser = User(anotherUserId, anotherUserEmail, anotherUserName, anotherUserPassword)
 
         /* request dto */

--- a/src/test/kotlin/com/example/chekitoki/domain/fixtures/UserFixtures.kt
+++ b/src/test/kotlin/com/example/chekitoki/domain/fixtures/UserFixtures.kt
@@ -1,0 +1,51 @@
+package com.example.chekitoki.domain.fixtures
+
+import com.example.chekitoki.domain.user.dto.UserRequestDto
+import com.example.chekitoki.domain.user.model.User
+
+class UserFixtures {
+    companion object {
+        const val userId = "test"
+        const val userEmail = "test@test.com"
+        const val userName = "테스트"
+        const val userPassword = "asdfqwer1234"
+        const val id = 1L
+
+        private const val modifiedName = "수정된 테스트"
+        private const val modifiedPassword = "qwer1234asdf"
+
+        private const val anotherUserId = "rnignon"
+        private const val anotherUserEmail = "rnignon@naver.com"
+        private const val anotherUserName = "rnignon"
+        private const val anotherUserPassword = "fdsarewq4321"
+        private const val anotherId = 2L
+
+        val testUser = User(userId, userEmail, userName, userPassword)
+        val modifiedUser = User(userId, userEmail, modifiedName, modifiedPassword)
+        val anotherUser = User(anotherUserId, anotherUserEmail, anotherUserName, anotherUserPassword)
+
+        /* request dto */
+        val LoginRequest = UserRequestDto.Login(userId, userPassword)
+        val WrongLoginRequest = UserRequestDto.Login(userId, "wrong-password")
+
+        val CreateRequest = UserRequestDto.Create(userId, userEmail, userName, userPassword)
+
+        val UpdateProfileRequest = UserRequestDto.UpdateProfile(modifiedName)
+
+        val UpdatePasswordRequest = UserRequestDto.UpdatePassword(userPassword, modifiedPassword)
+        val WrongUpdatePasswordRequest = UserRequestDto.UpdatePassword(userPassword + "wrong", modifiedPassword)
+        val DuplicatePasswordRequest = UserRequestDto.UpdatePassword(userPassword, userPassword)
+
+        /* info */
+        val LoginInfo = LoginRequest.toInfo()
+        val WrongLoginInfo = WrongLoginRequest.toInfo()
+
+        val CreateInfo = CreateRequest.toInfo()
+
+        val UpdateProfileInfo = UpdateProfileRequest.toInfo()
+
+        val UpdatePasswordInfo = UpdatePasswordRequest.toInfo()
+        val WrongUpdatePasswordInfo = WrongUpdatePasswordRequest.toInfo()
+        val DuplicatePasswordInfo = DuplicatePasswordRequest.toInfo()
+    }
+}

--- a/src/test/kotlin/com/example/chekitoki/domain/fixtures/UserFixtures.kt
+++ b/src/test/kotlin/com/example/chekitoki/domain/fixtures/UserFixtures.kt
@@ -36,7 +36,7 @@ class UserFixtures {
         val UpdateProfileRequest = UserRequestDto.UpdateProfile(modifiedName)
 
         val UpdatePasswordRequest = UserRequestDto.UpdatePassword(userPassword, modifiedPassword)
-        val WrongUpdatePasswordRequest = UserRequestDto.UpdatePassword(userPassword + "wrong", modifiedPassword)
+        val WrongUpdatePasswordRequest = UserRequestDto.UpdatePassword(userPassword + "wrong", "")
         val DuplicatePasswordRequest = UserRequestDto.UpdatePassword(userPassword, userPassword)
 
         /* info */

--- a/src/test/kotlin/com/example/chekitoki/domain/fixtures/UserFixtures.kt
+++ b/src/test/kotlin/com/example/chekitoki/domain/fixtures/UserFixtures.kt
@@ -1,17 +1,18 @@
 package com.example.chekitoki.domain.fixtures
 
+import com.example.chekitoki.domain.user.dto.UserInfo
 import com.example.chekitoki.domain.user.dto.UserRequestDto
 import com.example.chekitoki.domain.user.model.User
 
 class UserFixtures {
     companion object {
-        const val userId = "test"
+        const val userId = "testuser"
         const val userEmail = "test@test.com"
         const val userName = "테스트"
         const val userPassword = "asdfqwer1234"
         const val id = 1L
 
-        const val modifiedName = "수정된 테스트"
+        const val modifiedName = "수정된테스트"
         private const val modifiedPassword = "qwer1234asdf"
 
         private const val anotherUserId = "rnignon"
@@ -30,6 +31,7 @@ class UserFixtures {
         val WrongLoginRequest = UserRequestDto.Login(userId, "wrong-password")
 
         val CreateRequest = UserRequestDto.Create(userId, userEmail, userName, userPassword)
+        val WrongCreateRequest = UserRequestDto.Create("wrong!id?", "notemail", "123456789012345678901", "wrongpassword")
 
         val UpdateProfileRequest = UserRequestDto.UpdateProfile(modifiedName)
 
@@ -48,5 +50,11 @@ class UserFixtures {
         val UpdatePasswordInfo = UpdatePasswordRequest.toInfo()
         val WrongUpdatePasswordInfo = WrongUpdatePasswordRequest.toInfo()
         val DuplicatePasswordInfo = DuplicatePasswordRequest.toInfo()
+
+        /* response */
+        val UserResponseInfo = UserInfo.Response(id, userId, userEmail, userName)
+        val UserUpdatedResponseInfo = UserInfo.Response(id, userId, userEmail, modifiedName)
+        val DetailUserResponse = UserResponseInfo.toResponseDetail()
+        val SummaryUserResponse = UserResponseInfo.toResponseSummary()
     }
 }

--- a/src/test/kotlin/com/example/chekitoki/domain/user/controller/AuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/example/chekitoki/domain/user/controller/AuthenticationControllerTest.kt
@@ -1,0 +1,148 @@
+package com.example.chekitoki.domain.user.controller
+
+import com.example.chekitoki.config.auth.CustomUserDetails
+import com.example.chekitoki.domain.fixtures.UserFixtures
+import com.example.chekitoki.domain.user.exception.InvalidCredentialsException
+import com.example.chekitoki.domain.user.service.AuthenticationService
+import com.example.chekitoki.utils.CookieUtils
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.just
+import io.mockk.runs
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.BadCredentialsException
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.delete
+import org.springframework.test.web.servlet.patch
+import org.springframework.test.web.servlet.post
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AuthenticationControllerTest(
+    private val mockMvc: MockMvc,
+    private val objectMapper: ObjectMapper,
+    @MockkBean val authenticationService: AuthenticationService,
+) : DescribeSpec({
+    isolationMode = IsolationMode.InstancePerLeaf
+
+    describe("로그인 요청") {
+        context("올바른 양식으로 로그인 요청을 보낼 경우") {
+            every { authenticationService.login(any()) } returns UserFixtures.UserResponseInfo
+            it("로그인 성공 후 유저 정보를 반환") {
+                mockMvc.post("/api/auth/login") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(UserFixtures.LoginRequest)
+                }.andDo { print() }
+                    .andExpect {
+                    status { isOk() }
+                    content { contentType(MediaType.APPLICATION_JSON) }
+                    content {
+                        jsonPath("$.id") { value(UserFixtures.id) }
+                        jsonPath("$.userId") { value(UserFixtures.userId) }
+                        jsonPath("$.name") { value(UserFixtures.userName) }
+                        jsonPath("$.email") { value(UserFixtures.userEmail) }
+                    }
+                }
+            }
+        }
+        context("올바르지 않은 양식으로 로그인 요청을 보낼 경우") {
+            it("400 상태 코드 반환") {
+                mockMvc.post("/api/auth/login") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(
+                        mapOf("userId" to "test")
+                    )
+                }.andExpect {
+                    status { isOk() }
+                    content { contentType(MediaType.APPLICATION_JSON) }
+                    content {
+                        jsonPath("$.code") { value(400) }
+                    }
+                }
+            }
+        }
+        context("잘못된 정보로 로그인 요청을 보낼 경우") {
+            every { authenticationService.login(any()) } throws InvalidCredentialsException("")
+            it("401 상태 코드 반환") {
+                mockMvc.post("/api/auth/login") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(UserFixtures.WrongLoginRequest)
+                }.andDo { print() }
+                    .andExpect {
+                    status { isOk() }
+                    content { contentType(MediaType.APPLICATION_JSON) }
+                    content {
+                        jsonPath("$.code") { value(401) }
+                    }
+                }
+            }
+        }
+    }
+
+    describe("로그아웃 요청") {
+        context("로그인 상태로 로그아웃 요청을 보낼 경우") {
+            beforeTest {
+                val userDetails = CustomUserDetails(UserFixtures.testUser)
+                val authentication = UsernamePasswordAuthenticationToken(userDetails, null, userDetails.authorities)
+                SecurityContextHolder.getContext().authentication = authentication
+            }
+            it("로그아웃 성공 후 200 상태 코드 반환") {
+                mockMvc.delete("/api/auth/logout") {
+                    contentType = MediaType.APPLICATION_JSON
+                }.andExpect {
+                    status { isOk() }
+                }
+            }
+        }
+
+        context("로그인 상태가 아닌 상태로 로그아웃 요청을 보낼 경우") {
+            it("400 상태 코드 반환") {
+                mockMvc.delete("/api/auth/logout") {
+                    contentType = MediaType.APPLICATION_JSON
+                }.andExpect {
+                    status { isOk() }
+                    content { contentType(MediaType.APPLICATION_JSON) }
+                    content {
+                        jsonPath("$.code") { value(400) }
+                    }
+                }
+            }
+        }
+    }
+
+    describe("토큰 재발급 요청") {
+        context("리프레시 토큰을 가지고 재발급 요청을 보낼 경우") {
+            every { authenticationService.reissue() } just runs
+            it("재발급 성공 후 200 상태 코드 반환") {
+                mockMvc.patch("/api/auth/reissue") {
+                    contentType = MediaType.APPLICATION_JSON
+                }.andExpect {
+                    status { isOk() }
+                }
+            }
+        }
+        context("리프레시 토큰이 없는 상태로 재발급 요청을 보낼 경우") {
+            every { authenticationService.reissue() } throws CookieUtils.NoSuchCookieException(null)
+            it("404 상태 코드 반환") {
+                mockMvc.patch("/api/auth/reissue") {
+                    contentType = MediaType.APPLICATION_JSON
+                }.andExpect {
+                    status { isOk() }
+                    content { contentType(MediaType.APPLICATION_JSON) }
+                    content {
+                        jsonPath("$.code") { value(404) }
+                    }
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/example/chekitoki/domain/user/controller/UserControllerTest.kt
+++ b/src/test/kotlin/com/example/chekitoki/domain/user/controller/UserControllerTest.kt
@@ -1,0 +1,229 @@
+package com.example.chekitoki.domain.user.controller
+
+import com.example.chekitoki.config.auth.CustomUserDetails
+import com.example.chekitoki.domain.fixtures.UserFixtures
+import com.example.chekitoki.domain.user.exception.DuplicatePasswordException
+import com.example.chekitoki.domain.user.exception.DuplicateUserException
+import com.example.chekitoki.domain.user.exception.NoSuchUserException
+import com.example.chekitoki.domain.user.service.UserService
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.*
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.web.servlet.*
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class UserControllerTest(
+    private val mockMvc: MockMvc,
+    private val objectMapper: ObjectMapper,
+    @MockkBean val userService: UserService,
+) : DescribeSpec({
+    isolationMode = IsolationMode.InstancePerLeaf
+
+    beforeContainer {
+        val userDetails = CustomUserDetails(UserFixtures.testUser)
+        val authentication = UsernamePasswordAuthenticationToken(userDetails, null, userDetails.authorities)
+        SecurityContextHolder.getContext().authentication = authentication
+    }
+
+    describe("새로운 유저 정보 생성") {
+        context("올바른 정보로 유저를 생성할 경우") {
+            every { userService.createUser(any()) } returns UserFixtures.UserResponseInfo
+            it("생성한 유저의 정보를 담은 200 상태 코드 반환") {
+                mockMvc.post("/api/user") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(UserFixtures.CreateRequest)
+                }.andExpect {
+                    status { isOk() }
+                    content { contentType(MediaType.APPLICATION_JSON) }
+                    content {
+                        jsonPath("$.id") { value(UserFixtures.id) }
+                        jsonPath("$.userId") { value(UserFixtures.userId)}
+                        jsonPath("$.name") { value(UserFixtures.userName) }
+                        jsonPath("$.email") { value(UserFixtures.userEmail) }
+                    }
+                }
+            }
+        }
+
+        context("이미 존재하는 아이디 정보로 유저를 생성할 경우") {
+            every { userService.createUser(any()) } throws DuplicateUserException(null)
+            it("409 상태 코드 반환") {
+                mockMvc.post("/api/user") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(UserFixtures.CreateRequest)
+                }.andExpect {
+                    status { isOk() }
+                    content { contentType(MediaType.APPLICATION_JSON) }
+                    content {
+                        jsonPath("$.code") { value(409) }
+                    }
+                }
+            }
+        }
+
+        context("올바르지 않은 양식의 요청을 보낼 경우") {
+            it("400 상태 코드 반환") {
+                mockMvc.post("/api/user") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(UserFixtures.WrongCreateRequest)
+                }.andExpect {
+                    status { isOk() }
+                    content { contentType(MediaType.APPLICATION_JSON) }
+                    content {
+                        jsonPath("$.code") { value(400) }
+                    }
+                }
+            }
+        }
+
+        context("요구하는 필드가 누락된 경우") {
+            it("400 상태 코드 반환") {
+                mockMvc.post("/api/user") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(UserFixtures.CreateRequest.copy(email = ""))
+                }.andExpect {
+                    status { isOk() }
+                    content { contentType(MediaType.APPLICATION_JSON) }
+                    content {
+                        jsonPath("$.code") { value(400) }
+                    }
+                }
+            }
+        }
+    }
+
+    describe("유저 정보 조회") {
+        context("존재하는 유저의 정보를 조회할 경우") {
+            every { userService.getUser(any()) } returns UserFixtures.UserResponseInfo
+            it("유저 정보를 조회하고 200 상태 코드 반환") {
+                mockMvc.get("/api/user/${UserFixtures.id}")
+                    .andExpect {
+                        status { isOk() }
+                        content { contentType(MediaType.APPLICATION_JSON) }
+                        content {
+                            jsonPath("$.id") { value(UserFixtures.id) }
+                            jsonPath("$.userId") { value(UserFixtures.userId) }
+                            jsonPath("$.name") { value(UserFixtures.userName) }
+                            jsonPath("$.email") { value(UserFixtures.userEmail) }
+                        }
+                    }
+            }
+        }
+        context("존재하지 않는 유저의 정보를 조회할 경우") {
+            every { userService.getUser(any()) } throws NoSuchUserException(null)
+            it("404 상태 코드 반환") {
+                mockMvc.get("/api/user/999")
+                    .andExpect {
+                        status { isOk() }
+                        content { contentType(MediaType.APPLICATION_JSON) }
+                        content {
+                            jsonPath("$.code") { value(404) }
+                        }
+                    }
+            }
+        }
+    }
+
+    describe("유저 프로필 업데이트") {
+        context("올바른 정보로 유저 프로필을 업데이트할 경우") {
+            every { userService.updateProfile(any(), any()) } returns UserFixtures.UserUpdatedResponseInfo
+            it("유저 프로필을 업데이트하고 200 상태 코드 반환") {
+                mockMvc.patch("/api/user/update/profile") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(UserFixtures.UpdateProfileRequest)
+                }.andDo{print()}
+                    .andExpect {
+                        status { isOk() }
+                        content { contentType(MediaType.APPLICATION_JSON) }
+                        content {
+                            jsonPath("$.id") { value(UserFixtures.id) }
+                            jsonPath("$.userId") { value(UserFixtures.userId) }
+                            jsonPath("$.name") { value(UserFixtures.modifiedName) }
+                            jsonPath("$.email") { value(UserFixtures.userEmail) }
+                        }
+                    }
+            }
+        }
+
+        context("올바르지 않은 양식의 요청을 보낼 경우") {
+            it("400 상태 코드 반환") {
+                mockMvc.patch("/api/user/update/profile") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(UserFixtures.UpdateProfileRequest.copy(name = ""))
+                }.andExpect {
+                    status { isOk() }
+                    content { contentType(MediaType.APPLICATION_JSON) }
+                    content {
+                        jsonPath("$.code") { value(400) }
+                    }
+                }
+            }
+        }
+    }
+
+    describe("유저 비밀번호 업데이트") {
+        context("올바른 정보로 유저 비밀번호를 업데이트할 경우") {
+            every { userService.updatePassword(any(), any()) } just Runs
+            it("유저 비밀번호를 업데이트하고 200 상태 코드 반환") {
+                mockMvc.patch("/api/user/update/password") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(UserFixtures.UpdatePasswordRequest)
+                }.andExpect {
+                    status { isOk() }
+                }
+            }
+        }
+
+        context("올바르지 않은 양식의 요청을 보낼 경우") {
+            it("400 상태 코드 반환") {
+                mockMvc.patch("/api/user/update/password") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(UserFixtures.WrongUpdatePasswordRequest)
+                }.andDo { print() }
+                    .andExpect {
+                    status { isOk() }
+                    content { contentType(MediaType.APPLICATION_JSON) }
+                    content {
+                        jsonPath("$.code") { value(400) }
+                    }
+                }
+            }
+        }
+
+        context("이전 비밀번호와 새로운 비밀번호가 같을 경우") {
+            every { userService.updatePassword(any(), any()) } throws DuplicatePasswordException(null)
+            it("400 상태 코드 반환") {
+                mockMvc.patch("/api/user/update/password") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(UserFixtures.DuplicatePasswordRequest)
+                }.andDo { print() }
+                    .andExpect {
+                    status { isOk() }
+                    content { contentType(MediaType.APPLICATION_JSON) }
+                    content {
+                        jsonPath("$.code") { value(400) }
+                    }
+                }
+            }
+        }
+    }
+
+    describe("유저 삭제") {
+        every { userService.deleteUser(any()) } just Runs
+        it("유저를 삭제하고 200 상태 코드 반환") {
+            mockMvc.delete("/api/user") {
+                contentType = MediaType.APPLICATION_JSON
+            }.andExpect {
+                status { isOk() }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/example/chekitoki/domain/user/service/AuthenticationServiceTest.kt
+++ b/src/test/kotlin/com/example/chekitoki/domain/user/service/AuthenticationServiceTest.kt
@@ -1,0 +1,172 @@
+package com.example.chekitoki.domain.user.service
+
+import com.example.chekitoki.api.exception.BusinessException
+import com.example.chekitoki.config.auth.jwt.TokenProvider
+import com.example.chekitoki.domain.fixtures.UserFixtures
+import com.example.chekitoki.domain.token.model.RefreshToken
+import com.example.chekitoki.domain.token.repository.RefreshTokenRepository
+import com.example.chekitoki.domain.token.repository.RefreshTokenStore
+import com.example.chekitoki.domain.user.repository.UserRepository
+import com.example.chekitoki.domain.user.repository.UserStoreImpl
+import com.example.chekitoki.utils.CookieUtils
+import io.jsonwebtoken.Claims
+import io.jsonwebtoken.impl.DefaultClaims
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import jakarta.servlet.http.Cookie
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.authentication.BadCredentialsException
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.AuthenticationException
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+
+class AuthenticationServiceTest : DescribeSpec({
+    val tokenRepository: RefreshTokenRepository = mockk<RefreshTokenRepository>()
+    val tokenStore = RefreshTokenStore(tokenRepository)
+    val userRepository: UserRepository = mockk<UserRepository>()
+    val userStore: UserStore = UserStoreImpl(userRepository)
+
+    val authenticationManager: AuthenticationManager = mockk<AuthenticationManager>()
+    val tokenProvider: TokenProvider = mockk<TokenProvider>()
+
+    val authService = AuthenticationService(authenticationManager, tokenStore, tokenProvider, userStore)
+
+    val accessToken = "access-token-value"
+    val refreshToken = "refresh-token-value"
+
+    lateinit var mockRequest: MockHttpServletRequest
+    lateinit var mockResponse: MockHttpServletResponse
+
+    beforeEach {
+        mockRequest = MockHttpServletRequest()
+        mockResponse = MockHttpServletResponse()
+        RequestContextHolder.setRequestAttributes(ServletRequestAttributes(mockRequest, mockResponse))
+    }
+
+    describe("login") {
+        context("정상적인 로그인 요청이 주어진 경우") {
+            it("로그인에 성공하여 유저 정보를 반환한다.") {
+                every { authenticationManager.authenticate(any()) } returns mockk<Authentication>()
+                every { tokenProvider.generateToken(any(), true) } returns accessToken
+                every { tokenProvider.generateToken(any(), false) } returns refreshToken
+                every { userRepository.findByUserId(UserFixtures.userId) } returns UserFixtures.testUser
+                every { tokenRepository.save(any()) } returns RefreshToken(UserFixtures.testUser, refreshToken)
+
+                val result = authService.login(UserFixtures.LoginInfo)
+
+                val accessTokenCookie = mockResponse.getCookie(TokenProvider.ACCESS_TOKEN)
+                val refreshTokenCookie = mockResponse.getCookie(TokenProvider.REFRESH_TOKEN)
+
+                result.userId shouldBe UserFixtures.userId
+                accessTokenCookie shouldNotBe null
+                accessTokenCookie!!.value shouldBe accessToken
+                refreshTokenCookie shouldNotBe null
+                refreshTokenCookie!!.value shouldBe refreshToken
+            }
+        }
+
+        context("잘못된 정보로 로그인 유청이 주어진 경우") {
+            it("로그인에 실패하여 인증 예외를 던진다.") {
+                every { authenticationManager.authenticate(any()) } throws BadCredentialsException("Bad credentials")
+
+                shouldThrow<AuthenticationException> {
+                    authService.login(UserFixtures.WrongLoginInfo)
+                }
+            }
+        }
+    }
+
+    describe("logout") {
+        context("로그아웃 요청이 주어진 경우") {
+            beforeTest {
+                mockRequest.setCookies(
+                    Cookie(TokenProvider.ACCESS_TOKEN, accessToken),
+                    Cookie(TokenProvider.REFRESH_TOKEN, refreshToken)
+                )
+            }
+            it("로그아웃에 성공하여 토큰을 삭제한다.") {
+                every { tokenRepository.deleteByToken(refreshToken) } just Runs
+
+                authService.logout(UserFixtures.userId)
+
+                val accessTokenCookie = mockResponse.getCookie(TokenProvider.ACCESS_TOKEN)
+                val refreshTokenCookie = mockResponse.getCookie(TokenProvider.REFRESH_TOKEN)
+
+                accessTokenCookie!!.maxAge shouldBe 0
+                refreshTokenCookie!!.maxAge shouldBe 0
+            }
+        }
+
+        context("로그인 되어 있지 않은 상태에서 로그아웃 요청이 주어진 경우") {
+            it("로그아웃에 실패하여 예외를 던진다.") {
+                shouldThrow<BusinessException> {
+                    authService.logout(UserFixtures.userId)
+                }
+            }
+        }
+    }
+
+    describe("reissue") {
+        val mockClaims: Claims = DefaultClaims().apply {
+            put("sub", UserFixtures.userId)
+            put("role", listOf("USER"))
+        }
+        context("정상적인 토큰 재발급 요청이 주어진 경우") {
+            beforeTest {
+                mockRequest.setCookies(
+                    Cookie(TokenProvider.ACCESS_TOKEN, "expired-$accessToken"),
+                    Cookie(TokenProvider.REFRESH_TOKEN, refreshToken)
+                )
+            }
+            it("토큰을 재발급한다.") {
+                every { tokenProvider.validateTokenOrThrow(refreshToken) } just Runs
+                every { tokenProvider.getClaims(refreshToken) } returns mockClaims
+                every { userRepository.findByUserId(UserFixtures.userId) } returns UserFixtures.testUser
+                every { tokenProvider.generateToken(any(), true) } returns "new$accessToken"
+                every { tokenProvider.generateToken(any(), false) } returns "new$refreshToken"
+                every { tokenRepository.findByToken(refreshToken) } returns RefreshToken(UserFixtures.testUser, refreshToken)
+
+                authService.reissue()
+
+                val accessTokenCookie = mockResponse.getCookie(TokenProvider.ACCESS_TOKEN)
+                val refreshTokenCookie = mockResponse.getCookie(TokenProvider.REFRESH_TOKEN)
+
+                accessTokenCookie!!.value shouldBe "new$accessToken"
+                refreshTokenCookie!!.value shouldBe "new$refreshToken"
+            }
+        }
+
+        context("쿠키에 저장된 토큰이 존재하지 않는 경우") {
+            it("토큰 재발급에 실패하여 예외를 던진다.") {
+                shouldThrow<CookieUtils.NoSuchCookieException> {
+                    authService.reissue()
+                }
+            }
+        }
+
+        context("유효하지 않은 토큰이 주어진 경우") {
+            beforeTest {
+                mockRequest.setCookies(
+                    Cookie(TokenProvider.ACCESS_TOKEN, "invalid-$accessToken"),
+                    Cookie(TokenProvider.REFRESH_TOKEN, refreshToken)
+                )
+            }
+            it("토큰 재발급에 실패하여 예외를 던진다.") {
+                every { tokenProvider.validateTokenOrThrow(refreshToken) } throws TokenProvider.InvalidTokenException()
+
+                shouldThrow<TokenProvider.InvalidTokenException> {
+                    authService.reissue()
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/example/chekitoki/domain/user/service/AuthenticationServiceTest.kt
+++ b/src/test/kotlin/com/example/chekitoki/domain/user/service/AuthenticationServiceTest.kt
@@ -6,6 +6,7 @@ import com.example.chekitoki.domain.fixtures.UserFixtures
 import com.example.chekitoki.domain.token.model.RefreshToken
 import com.example.chekitoki.domain.token.repository.RefreshTokenRepository
 import com.example.chekitoki.domain.token.repository.RefreshTokenStore
+import com.example.chekitoki.domain.user.exception.InvalidCredentialsException
 import com.example.chekitoki.domain.user.repository.UserRepository
 import com.example.chekitoki.domain.user.repository.UserStoreImpl
 import com.example.chekitoki.utils.CookieUtils
@@ -78,7 +79,7 @@ class AuthenticationServiceTest : DescribeSpec({
             it("로그인에 실패하여 인증 예외를 던진다.") {
                 every { authenticationManager.authenticate(any()) } throws BadCredentialsException("Bad credentials")
 
-                shouldThrow<AuthenticationException> {
+                shouldThrow<InvalidCredentialsException> {
                     authService.login(UserFixtures.WrongLoginInfo)
                 }
             }

--- a/src/test/kotlin/com/example/chekitoki/domain/user/service/UserServiceTest.kt
+++ b/src/test/kotlin/com/example/chekitoki/domain/user/service/UserServiceTest.kt
@@ -1,0 +1,118 @@
+package com.example.chekitoki.domain.user.service
+
+import com.example.chekitoki.config.PasswordEncoderWrapper
+import com.example.chekitoki.domain.fixtures.UserFixtures
+import com.example.chekitoki.domain.user.exception.NoSuchUserException
+import com.example.chekitoki.domain.user.repository.UserRepository
+import com.example.chekitoki.domain.user.repository.UserStoreImpl
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.*
+import java.util.*
+
+class UserServiceTest : DescribeSpec({
+    val userRepository: UserRepository = mockk<UserRepository>()
+    val userStore: UserStore = UserStoreImpl(userRepository)
+    val encoder: PasswordEncoderWrapper = mockk()
+    val userService: UserService = UserService(userStore, encoder)
+
+    describe("createUser") {
+        beforeEach { every { encoder.encode(any()) } returns "encodedPassword" }
+        context("정상적인 회원 가입 요청이 주어진 경우") {
+            it("새로운 유저를 성공적으로 생성한다.") {
+                every { userRepository.findById(UserFixtures.id) } returns Optional.of(UserFixtures.testUser)
+
+                val result = userService.createUser(UserFixtures.CreateInfo)
+
+                result.userId shouldBe UserFixtures.userId
+                result.name shouldBe UserFixtures.userName
+                result.email shouldBe UserFixtures.userEmail
+            }
+        }
+
+        context("이미 존재하는 아이디로 회원가입을 시도하면") {
+            it("중복 유저 예외를 던진다.") {
+                every { userRepository.existsByUserId(UserFixtures.userId) } returns true
+
+                shouldThrow<DuplicateUserException> {
+                    userService.createUser(UserFixtures.CreateInfo)
+                }
+            }
+        }
+    }
+
+    describe("getUser") {
+        context("존재하는 유저에 대한 정보를 요청하면") {
+            it("유저 정보를 반환한다.") {
+                every { userRepository.findById(UserFixtures.id) } returns Optional.of(UserFixtures.testUser)
+
+                val result = userService.getUser(UserFixtures.id)
+
+                result.userId shouldBe UserFixtures.userId
+            }
+        }
+
+        context("존재하지 않는 유저에 대한 정보를 요청하면") {
+            it("유저 정보가 존재하지 않는다는 예외를 던진다.") {
+                every { userRepository.findById(UserFixtures.id) } returns Optional.empty()
+
+                shouldThrow<NoSuchUserException> {
+                    userService.getUser(UserFixtures.id)
+                }
+            }
+        }
+    }
+
+    describe("updateProfile") {
+        context("정상적인 프로필 수정 요청이 주어진 경우") {
+            it("유저의 프로필을 수정한다.") {
+                every { userRepository.findByUserId(UserFixtures.userId) } returns UserFixtures.testUser
+
+                val result = userService.updateProfile(UserFixtures.userId, UserFixtures.UpdateProfileInfo)
+
+                result.name shouldBe UserFixtures.modifiedName
+            }
+        }
+    }
+
+    describe("updatePassword") {
+        context("정상적인 비밀번호 수정 요청이 주어진 경우") {
+            it("유저의 비밀번호를 수정한다.") {
+                every { userRepository.findByUserId(UserFixtures.userId) } returns UserFixtures.testUser
+
+                userService.updatePassword(UserFixtures.userId, UserFixtures.UpdatePasswordInfo)
+            }
+        }
+
+        context("유저가 입력한 이전 비밀번호가 일치하지 않으면") {
+            it("비밃번호 불일치 예외를 던진다.") {
+                every { userRepository.findByUserId(UserFixtures.userId) } returns UserFixtures.testUser
+
+                shouldThrow<InvalidPasswordException> {
+                    userService.updatePassword(UserFixtures.userId, UserFixtures.WrongUpdatePasswordInfo)
+                }
+            }
+        }
+
+        context("유저가 입력한 새로운 비밀번호가 이전 비밀번호와 동일하면") {
+            it("새로운 비밀번호가 이전 비밀번호와 동일하다는 예외를 던진다.") {
+                every { userRepository.findByUserId(UserFixtures.userId) } returns UserFixtures.testUser
+
+                shouldThrow<DuplicatePasswordException> {
+                    userService.updatePassword(UserFixtures.userId, UserFixtures.DuplicatePasswordInfo)
+                }
+            }
+        }
+    }
+
+    describe("deleteUser") {
+        context("정상적인 회원 탈퇴 요청이 주어진 경우") {
+            it("유저를 삭제한다.") {
+                every { userRepository.findByUserId(UserFixtures.userId) } returns UserFixtures.testUser
+
+                userService.deleteUser(UserFixtures.userId)
+            }
+        }
+    }
+})


### PR DESCRIPTION
close #11 

- 유저 도메인 관련 테스트코드 작성
  - `UserController` 및 `AuthenticationController` 테스트 추가  
  - `UserService` 및 `AuthenticationService` 테스트 추가  
- 예외 처리 및 유효성 검증 관련 기능 수행
  - `RequestDTO` 필드별 유효성 검사 조건 설정  
  - `UserController` 및 `AuthenticationController`에 `@Valid` 적용  